### PR TITLE
[CALCITE-3557] Get real data instead of from nested multiset

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -2115,6 +2115,32 @@ public class JdbcTest {
         .returnsUnordered("A=[{10}, {20}, {10}, {10}]");
   }
 
+  @Test public void testCollectionOrMapInMultiset() {
+    CalciteAssert.that()
+        .query("select multiset[array[1, 2], array[3, 4]]")
+        .returns("EXPR$0=[[1, 2], [3, 4]]\n");
+
+    CalciteAssert.that()
+        .query("select multiset[map[1, 2], map[3, 4]]")
+        .returns("EXPR$0=[{1=2}, {3=4}]\n");
+
+    CalciteAssert.that()
+        .query("select multiset[multiset[1, 2], multiset[3, 4]]")
+        .returns("EXPR$0=[[1, 2], [3, 4]]\n");
+
+    CalciteAssert.that()
+        .query("select multiset[multiset[array[1, 2]]]")
+        .returns("EXPR$0=[[[1, 2]]]\n");
+
+    CalciteAssert.that()
+        .query("select multiset[multiset[multiset[1, 2]]]")
+        .returns("EXPR$0=[[[1, 2]]]\n");
+
+    CalciteAssert.that()
+        .query("select multiset[multiset[multiset[multiset[1, 2]]]]")
+        .returns("EXPR$0=[[[[1, 2]]]]\n");
+  }
+
   @Test void testUnnestArray() {
     CalciteAssert.that()
         .query("select*from unnest(array[1,2])")


### PR DESCRIPTION
The result for select multiset[multiset[1, 2]] is List{List{Object{1}, Object{2}}}, because we won't take out the real data in the list.
I wrote a function to recursively take out the real data, the right result will be List{List{1,2}}.